### PR TITLE
Add 'qtwayland5' package to snapcraft.yml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,6 +64,7 @@
         - libopencv-objdetect2.4v5
         - libopencv-photo2.4v5
         - libopencv-video2.4v5
+        - qtwayland5
       after: [desktop-qt5]
 
   apps:


### PR DESCRIPTION
Patch for Fugio bug #65 :  Fugio missing 'wayland-egl' package startup error.

https://github.com/bigfug/Fugio/issues/65