### PR TITLE
Platform-indipendent fullscreen shortcut for PainterWindow

### DIFF
--- a/plugins/Image/painterwindow.cpp
+++ b/plugins/Image/painterwindow.cpp
@@ -106,5 +106,23 @@ bool PainterWindow::event(QEvent *event)
 		renderNow();
 		return true;
 	}
+    else if (event->type() == QEvent::KeyPress)
+	{
+		//Use F11 as a platform-indipendent shortcut for the PainterWindow
+		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+		if (keyEvent->key() == Qt::Key_F11)
+		{
+			if (this->visibility()==QWindow::FullScreen)
+			{
+				this->showNormal();
+			}
+			else
+			{
+				//Goes to fullScreen
+				this->showFullScreen();
+			}
+			return true;
+		}
+	}
 	return QWindow::event(event);
 }


### PR DESCRIPTION
After my post on the facebook Fugio users group to set the painter window in fullscreen on Windows, I didn't succeed in directly resolving the issue. Seems like Ctrl+enter on windows only works on x86 computers https://support.microsoft.com/en-us/help/81823/alt-enter-switches-between-window-and-full-screen
So, I decided to add F11 as a platform-indipendent shortcut directly in the source code.

Do I have to merge this change to your develop branch or to the release/3.1.0 one?
Since it's a small quantity of code and it's really useful for windows users, I thought it could go to release/3.1.0 in order to be published in the weekly builds.
If not, I can create the request to the develop branch.

Let me know what you prefer and if my code is ok to be merged.

I have only tested it on Fedora Linux.

Thank you in advance